### PR TITLE
Discard selection on outside click

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@types/prop-types": "^15.7.2",
         "@types/react": "^16.9.20",
         "@types/react-dom": "^16.9.5",
+        "@types/react-outside-click-handler": "^1.3.0",
         "@types/uuid": "^3.4.7",
         "@typescript-eslint/eslint-plugin": "^2.20.0",
         "@typescript-eslint/parser": "^2.20.0",
@@ -84,6 +85,7 @@
     "dependencies": {
         "react-dnd": "~10.0.2",
         "react-dnd-html5-backend": "~10.0.2",
+        "react-outside-click-handler": "~1.3.0",
         "uuid": "~3.4.0"
     },
     "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "stylelint-config-recommended-scss": "^4.2.0",
         "stylelint-scss": "^3.13.0",
         "ts-jest": "^24.2.0",
-        "typescript": "^3.6.5"
+        "typescript": "~3.6.2"
     },
     "dependencies": {
         "react-dnd": "~10.0.2",

--- a/src/component/FlowModeler.scss
+++ b/src/component/FlowModeler.scss
@@ -126,6 +126,9 @@
             }
         }
     }
+    & .gateway-element.diverging + .menu {
+        top: ($strokeStrength * 3) + (1.1em / 2);
+    }
     & .stroke-horizontal::before,
     & .stroke-vertical::before {
         background-color: $strokeColor;
@@ -183,7 +186,14 @@
             min-height: $strokeStrength * 4;
         }
         & > .bottom-spacing {
-            margin-top: $strokeStrength / 2;
+            display: flex;
+            flex-direction: column;
+            margin-bottom: $strokeStrength / 2;
+        }
+        & .clickable-spacing {
+            min-height: $strokeStrength * 4;
+            max-height: $strokeStrength * 8;
+            width: 100%;
         }
     }
     & .stroke-vertical {
@@ -212,12 +222,14 @@
     }
     &.editable {
         & .flow-element,
-        & .top-label {
+        & .top-label,
+        & .clickable-spacing {
             cursor: context-menu;
         }
         & .flow-element.end-element,
         & .selected.flow-element,
-        & .selected > .top-label {
+        & .selected .top-label,
+        & .selected .clickable-spacing {
             cursor: inherit;
         }
         & .start-element.selected,

--- a/src/component/FlowModeler.scss
+++ b/src/component/FlowModeler.scss
@@ -171,7 +171,7 @@
             z-index: -1;
         }
         &.can-drop::before {
-            background-color: $dropStrokeColor;
+            background: linear-gradient(90deg, $strokeColor 0%, $dropStrokeColor 62%);
         }
         & > .top-label {
             display: flex;

--- a/src/component/FlowModeler.tsx
+++ b/src/component/FlowModeler.tsx
@@ -223,22 +223,30 @@ export class FlowModeler extends React.Component<FlowModelerProps, FlowModelerSt
         };
     };
 
-    render(): React.ReactElement {
+    renderMain(): React.ReactElement {
         const { flow, options, onChange } = this.props;
         const { gridCellData, columnCount } = buildRenderData(flow, options && options.verticalAlign === "bottom" ? "bottom" : "top");
         return (
-            <OutsideClickHandler onOutsideClick={this.handleOnOutsideClick}>
-                <DndProvider backend={Backend}>
-                    <div
-                        className={`flow-modeler${onChange ? " editable" : ""}`}
-                        onClick={onChange ? this.clearSelection : undefined}
-                        style={{ gridTemplateColumns: `repeat(${columnCount}, max-content)` }}
-                    >
-                        {gridCellData.map(this.renderGridCell(!!onChange))}
-                    </div>
-                </DndProvider>
-            </OutsideClickHandler>
+            <div
+                className={`flow-modeler${onChange ? " editable" : ""}`}
+                onClick={onChange ? this.clearSelection : undefined}
+                style={{ gridTemplateColumns: `repeat(${columnCount}, max-content)` }}
+            >
+                {gridCellData.map(this.renderGridCell(!!onChange))}
+            </div>
         );
+    }
+
+    render(): React.ReactElement {
+        const { onChange, options } = this.props;
+        if (onChange) {
+            return (
+                <OutsideClickHandler onOutsideClick={this.handleOnOutsideClick}>
+                    {options && options.omitDndProvider ? this.renderMain() : <DndProvider backend={Backend}>{this.renderMain()}</DndProvider>}
+                </OutsideClickHandler>
+            );
+        }
+        return this.renderMain();
     }
 
     static propTypes = {
@@ -263,7 +271,8 @@ export class FlowModeler extends React.Component<FlowModelerProps, FlowModelerSt
             ).isRequired
         }).isRequired,
         options: PropTypes.shape({
-            verticalAlign: PropTypes.oneOf(["top", "middle", "bottom"])
+            verticalAlign: PropTypes.oneOf(["top", "middle", "bottom"]),
+            omitDndProvider: PropTypes.bool
         }),
         renderStep: PropTypes.func.isRequired,
         renderGatewayConditionType: PropTypes.func,

--- a/src/component/FlowModeler.tsx
+++ b/src/component/FlowModeler.tsx
@@ -1,5 +1,6 @@
 import * as PropTypes from "prop-types";
 import * as React from "react";
+import OutsideClickHandler from "react-outside-click-handler";
 import { DndProvider } from "react-dnd";
 import Backend from "react-dnd-html5-backend";
 
@@ -94,6 +95,12 @@ export class FlowModeler extends React.Component<FlowModelerProps, FlowModelerSt
     clearSelection = (event: React.MouseEvent): void => {
         this.onSelect(null);
         event.stopPropagation();
+    };
+
+    handleOnOutsideClick = (): void => {
+        if (this.state.selection !== null) {
+            this.onSelect(null);
+        }
     };
 
     handleOnChange = (change: (originalFlow: FlowModelerProps["flow"]) => EditActionResult): void => {
@@ -220,15 +227,17 @@ export class FlowModeler extends React.Component<FlowModelerProps, FlowModelerSt
         const { flow, options, onChange } = this.props;
         const { gridCellData, columnCount } = buildRenderData(flow, options && options.verticalAlign === "bottom" ? "bottom" : "top");
         return (
-            <DndProvider backend={Backend}>
-                <div
-                    className={`flow-modeler${onChange ? " editable" : ""}`}
-                    onClick={onChange ? this.clearSelection : undefined}
-                    style={{ gridTemplateColumns: `repeat(${columnCount}, max-content)` }}
-                >
-                    {gridCellData.map(this.renderGridCell(!!onChange))}
-                </div>
-            </DndProvider>
+            <OutsideClickHandler onOutsideClick={this.handleOnOutsideClick}>
+                <DndProvider backend={Backend}>
+                    <div
+                        className={`flow-modeler${onChange ? " editable" : ""}`}
+                        onClick={onChange ? this.clearSelection : undefined}
+                        style={{ gridTemplateColumns: `repeat(${columnCount}, max-content)` }}
+                    >
+                        {gridCellData.map(this.renderGridCell(!!onChange))}
+                    </div>
+                </DndProvider>
+            </OutsideClickHandler>
         );
     }
 

--- a/src/component/HorizontalStroke.tsx
+++ b/src/component/HorizontalStroke.tsx
@@ -64,7 +64,9 @@ export class HorizontalStroke extends React.Component<
                             <div
                                 className="bottom-spacing"
                                 style={(children && this.topLabelRef.current && { minHeight: `${this.state.wrapperTopHeight}px` }) || undefined}
-                            />
+                            >
+                                <div className="clickable-spacing" onClick={this.onTopLabelClick} />
+                            </div>
                         </>
                     )}
                 </div>

--- a/src/types/FlowModelerProps.ts
+++ b/src/types/FlowModelerProps.ts
@@ -20,6 +20,7 @@ export interface FlowModelerProps {
     };
     options?: {
         verticalAlign?: "top" | "middle" | "bottom";
+        omitDndProvider?: boolean;
     };
     renderStep: (target: StepNode) => React.ReactNode;
     renderGatewayConditionType?: (target: DivergingGatewayNode) => React.ReactNode;

--- a/test/component/FlowModeler.test.tsx
+++ b/test/component/FlowModeler.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
 
 import { FlowModeler } from "../../src/component/FlowModeler";
 
@@ -34,5 +34,33 @@ describe("renders correctly", () => {
             />
         );
         expect(component).toMatchSnapshot();
+    });
+    it.each`
+        elementType             | cssSelector
+        ${"start node"}         | ${".start-element"}
+        ${"step node"}          | ${".step-element"}
+        ${"diverging gateway"}  | ${".gateway-element.diverging"}
+        ${"converging gateway"} | ${".gateway-element.converging"}
+    `("when selecting $elementType", ({ cssSelector }) => {
+        const component = mount(
+            <FlowModeler
+                flow={simpleFlow}
+                renderStep={({ data }): React.ReactNode => <>{data.label}</>}
+                renderGatewayConditionType={({ data }): React.ReactNode => <>{data.label}</>}
+                renderGatewayConditionValue={({ data }): React.ReactNode => <>{data.label}</>}
+                onChange={(): void => {}}
+            />
+        );
+        let targetNode = component.find(cssSelector).at(0);
+        expect(targetNode.hasClass("selected")).toBe(false);
+        expect(component.find(".menu").exists()).toBe(false);
+
+        const onClick = targetNode.prop("onClick") as (event: React.MouseEvent) => void;
+        onClick({ stopPropagation: (): void => {} } as React.MouseEvent);
+        component.update();
+
+        targetNode = component.find(cssSelector).at(0);
+        expect(targetNode.hasClass("selected")).toBe(true);
+        expect(component.find(".menu").exists()).toBe(true);
     });
 });

--- a/test/component/__snapshots__/FlowModeler.test.tsx.snap
+++ b/test/component/__snapshots__/FlowModeler.test.tsx.snap
@@ -1,577 +1,591 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly with all render props 1`] = `
-<DndProvider
-  backend={[Function]}
+<OutsideClickHandler
+  disabled={false}
+  display="block"
+  onOutsideClick={[Function]}
+  useCapture={true}
 >
-  <div
-    className="flow-modeler"
-    style={
-      Object {
-        "gridTemplateColumns": "repeat(8, max-content)",
-      }
-    }
+  <DndProvider
+    backend={[Function]}
   >
-    <Component
-      colStartIndex={1}
-      key="1-1"
-      rowStartIndex={3}
-    >
-      <div
-        className="flow-element start-element"
-        onClick={[Function]}
-      />
-    </Component>
-    <Component
-      colStartIndex={2}
-      key="2-1"
-      rowStartIndex={3}
-    >
-      <StepElement
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "colStartIndex": 2,
-            "columnIndex": 2,
-            "data": Object {
-              "label": "First Node",
-            },
-            "followingElement": DivergingGatewayNode { "id": "2" },
-            "id": "1",
-            "precedingElement": StartNode,
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "step",
-          }
+    <div
+      className="flow-modeler"
+      style={
+        Object {
+          "gridTemplateColumns": "repeat(8, max-content)",
         }
-      >
-        First Node
-      </StepElement>
-    </Component>
-    <Component
-      colStartIndex={3}
-      key="3-1"
-      rowStartIndex={3}
-    >
-      <Gateway
-        gateway={
-          Object {
-            "colStartIndex": 3,
-            "columnIndex": 3,
-            "data": Object {
-              "label": "Alternatives",
-            },
-            "followingBranches": Array [
-              DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-              DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-              DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-            ],
-            "id": "2",
-            "precedingElement": StepNode { "id": "1" },
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "div-gw",
-          }
-        }
-        onSelect={[Function]}
-      >
-        <label>
-          Alternatives
-        </label>
-      </Gateway>
-    </Component>
-    <Component
-      colStartIndex={4}
-      key="4-1"
-      rowStartIndex={1}
-    >
-      <HorizontalStroke
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "branchIndex": 0,
-            "colEndIndex": undefined,
-            "colStartIndex": 4,
-            "columnIndex": 4,
-            "connectionType": 1,
-            "data": Object {
-              "label": "Stop Here",
-            },
-            "followingElement": ConvergingGatewayBranch,
-            "precedingElement": DivergingGatewayNode { "id": "2" },
-            "rowCount": 1,
-            "rowEndIndex": 2,
-            "rowStartIndex": 1,
-            "type": "div-branch",
-          }
-        }
-      >
-        <span>
-          Stop Here
-        </span>
-      </HorizontalStroke>
-    </Component>
-    <Component
-      colEndIndex={7}
-      colStartIndex={5}
-      key="5-1"
-      rowStartIndex={1}
-    >
-      <div
-        className="stroke-horizontal"
-      />
-      <div
-        className="stroke-vertical bottom-half"
-      />
-    </Component>
-    <Component
-      colStartIndex={7}
-      key="7-1"
-      rowStartIndex={3}
-    >
-      <Gateway
-        gateway={
-          Object {
-            "colStartIndex": 7,
-            "columnIndex": 7,
-            "followingElement": EndNode,
-            "precedingBranches": Array [
-              ConvergingGatewayBranch,
-              ConvergingGatewayBranch,
-              ConvergingGatewayBranch,
-            ],
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "conv-gw",
-          }
-        }
-        onSelect={[Function]}
-      />
-    </Component>
-    <Component
-      colStartIndex={8}
-      key="8-1"
-      rowStartIndex={3}
+      }
     >
       <Component
-        elementTypeClassName="end-element"
-        referenceElement={
-          Object {
-            "colStartIndex": 8,
-            "columnIndex": 8,
-            "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "end",
-          }
-        }
-      />
-    </Component>
-    <Component
-      colStartIndex={4}
-      key="4-2"
-      rowStartIndex={2}
-    >
-      <HorizontalStroke
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "branchIndex": 1,
-            "colEndIndex": undefined,
-            "colStartIndex": 4,
-            "columnIndex": 4,
-            "connectionType": 2,
-            "data": Object {
-              "label": "Continue",
-            },
-            "followingElement": StepNode { "id": "3.2" },
-            "precedingElement": DivergingGatewayNode { "id": "2" },
-            "rowCount": 1,
-            "rowEndIndex": 3,
-            "rowStartIndex": 2,
-            "type": "div-branch",
-          }
-        }
+        colStartIndex={1}
+        key="1-1"
+        rowStartIndex={3}
       >
-        <span>
-          Continue
-        </span>
-      </HorizontalStroke>
-    </Component>
-    <Component
-      colStartIndex={5}
-      key="5-2"
-      rowStartIndex={2}
-    >
-      <StepElement
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "colStartIndex": 5,
-            "columnIndex": 5,
-            "data": Object {
-              "label": "Second Node",
-            },
-            "followingElement": ConvergingGatewayBranch,
-            "id": "3.2",
-            "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-            "rowCount": 1,
-            "rowEndIndex": 3,
-            "rowStartIndex": 2,
-            "type": "step",
-          }
-        }
+        <div
+          className="flow-element start-element"
+          onClick={[Function]}
+        />
+      </Component>
+      <Component
+        colStartIndex={2}
+        key="2-1"
+        rowStartIndex={3}
       >
-        Second Node
-      </StepElement>
-    </Component>
-    <Component
-      colEndIndex={7}
-      colStartIndex={6}
-      key="6-2"
-      rowStartIndex={2}
-    >
-      <div
-        className="stroke-horizontal"
-      />
-      <div
-        className="stroke-vertical full-height"
-      />
-    </Component>
-    <Component
-      colStartIndex={4}
-      key="4-3"
-      rowStartIndex={3}
-    >
-      <HorizontalStroke
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "branchIndex": 2,
-            "colEndIndex": undefined,
-            "colStartIndex": 4,
-            "columnIndex": 4,
-            "connectionType": 3,
-            "data": Object {
-              "label": "Unless it is already done",
-            },
-            "followingElement": ConvergingGatewayBranch,
-            "precedingElement": DivergingGatewayNode { "id": "2" },
-            "rowCount": 1,
-            "rowEndIndex": 4,
-            "rowStartIndex": 3,
-            "type": "div-branch",
+        <StepElement
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "colStartIndex": 2,
+              "columnIndex": 2,
+              "data": Object {
+                "label": "First Node",
+              },
+              "followingElement": DivergingGatewayNode { "id": "2" },
+              "id": "1",
+              "precedingElement": StartNode,
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "step",
+            }
           }
-        }
+        >
+          First Node
+        </StepElement>
+      </Component>
+      <Component
+        colStartIndex={3}
+        key="3-1"
+        rowStartIndex={3}
       >
-        <span>
-          Unless it is already done
-        </span>
-      </HorizontalStroke>
-    </Component>
-    <Component
-      colEndIndex={7}
-      colStartIndex={5}
-      key="5-3"
-      rowStartIndex={3}
-    >
-      <div
-        className="stroke-horizontal"
-      />
-      <div
-        className="stroke-vertical top-half"
-      />
-    </Component>
-  </div>
-</DndProvider>
+        <Gateway
+          gateway={
+            Object {
+              "colStartIndex": 3,
+              "columnIndex": 3,
+              "data": Object {
+                "label": "Alternatives",
+              },
+              "followingBranches": Array [
+                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+                DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+              ],
+              "id": "2",
+              "precedingElement": StepNode { "id": "1" },
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "div-gw",
+            }
+          }
+          onSelect={[Function]}
+        >
+          <label>
+            Alternatives
+          </label>
+        </Gateway>
+      </Component>
+      <Component
+        colStartIndex={4}
+        key="4-1"
+        rowStartIndex={1}
+      >
+        <HorizontalStroke
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "branchIndex": 0,
+              "colEndIndex": undefined,
+              "colStartIndex": 4,
+              "columnIndex": 4,
+              "connectionType": 1,
+              "data": Object {
+                "label": "Stop Here",
+              },
+              "followingElement": ConvergingGatewayBranch,
+              "precedingElement": DivergingGatewayNode { "id": "2" },
+              "rowCount": 1,
+              "rowEndIndex": 2,
+              "rowStartIndex": 1,
+              "type": "div-branch",
+            }
+          }
+        >
+          <span>
+            Stop Here
+          </span>
+        </HorizontalStroke>
+      </Component>
+      <Component
+        colEndIndex={7}
+        colStartIndex={5}
+        key="5-1"
+        rowStartIndex={1}
+      >
+        <div
+          className="stroke-horizontal"
+        />
+        <div
+          className="stroke-vertical bottom-half"
+        />
+      </Component>
+      <Component
+        colStartIndex={7}
+        key="7-1"
+        rowStartIndex={3}
+      >
+        <Gateway
+          gateway={
+            Object {
+              "colStartIndex": 7,
+              "columnIndex": 7,
+              "followingElement": EndNode,
+              "precedingBranches": Array [
+                ConvergingGatewayBranch,
+                ConvergingGatewayBranch,
+                ConvergingGatewayBranch,
+              ],
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "conv-gw",
+            }
+          }
+          onSelect={[Function]}
+        />
+      </Component>
+      <Component
+        colStartIndex={8}
+        key="8-1"
+        rowStartIndex={3}
+      >
+        <Component
+          elementTypeClassName="end-element"
+          referenceElement={
+            Object {
+              "colStartIndex": 8,
+              "columnIndex": 8,
+              "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "end",
+            }
+          }
+        />
+      </Component>
+      <Component
+        colStartIndex={4}
+        key="4-2"
+        rowStartIndex={2}
+      >
+        <HorizontalStroke
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "branchIndex": 1,
+              "colEndIndex": undefined,
+              "colStartIndex": 4,
+              "columnIndex": 4,
+              "connectionType": 2,
+              "data": Object {
+                "label": "Continue",
+              },
+              "followingElement": StepNode { "id": "3.2" },
+              "precedingElement": DivergingGatewayNode { "id": "2" },
+              "rowCount": 1,
+              "rowEndIndex": 3,
+              "rowStartIndex": 2,
+              "type": "div-branch",
+            }
+          }
+        >
+          <span>
+            Continue
+          </span>
+        </HorizontalStroke>
+      </Component>
+      <Component
+        colStartIndex={5}
+        key="5-2"
+        rowStartIndex={2}
+      >
+        <StepElement
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "colStartIndex": 5,
+              "columnIndex": 5,
+              "data": Object {
+                "label": "Second Node",
+              },
+              "followingElement": ConvergingGatewayBranch,
+              "id": "3.2",
+              "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+              "rowCount": 1,
+              "rowEndIndex": 3,
+              "rowStartIndex": 2,
+              "type": "step",
+            }
+          }
+        >
+          Second Node
+        </StepElement>
+      </Component>
+      <Component
+        colEndIndex={7}
+        colStartIndex={6}
+        key="6-2"
+        rowStartIndex={2}
+      >
+        <div
+          className="stroke-horizontal"
+        />
+        <div
+          className="stroke-vertical full-height"
+        />
+      </Component>
+      <Component
+        colStartIndex={4}
+        key="4-3"
+        rowStartIndex={3}
+      >
+        <HorizontalStroke
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "branchIndex": 2,
+              "colEndIndex": undefined,
+              "colStartIndex": 4,
+              "columnIndex": 4,
+              "connectionType": 3,
+              "data": Object {
+                "label": "Unless it is already done",
+              },
+              "followingElement": ConvergingGatewayBranch,
+              "precedingElement": DivergingGatewayNode { "id": "2" },
+              "rowCount": 1,
+              "rowEndIndex": 4,
+              "rowStartIndex": 3,
+              "type": "div-branch",
+            }
+          }
+        >
+          <span>
+            Unless it is already done
+          </span>
+        </HorizontalStroke>
+      </Component>
+      <Component
+        colEndIndex={7}
+        colStartIndex={5}
+        key="5-3"
+        rowStartIndex={3}
+      >
+        <div
+          className="stroke-horizontal"
+        />
+        <div
+          className="stroke-vertical top-half"
+        />
+      </Component>
+    </div>
+  </DndProvider>
+</OutsideClickHandler>
 `;
 
 exports[`renders correctly with minimal/default props 1`] = `
-<DndProvider
-  backend={[Function]}
+<OutsideClickHandler
+  disabled={false}
+  display="block"
+  onOutsideClick={[Function]}
+  useCapture={true}
 >
-  <div
-    className="flow-modeler"
-    style={
-      Object {
-        "gridTemplateColumns": "repeat(8, max-content)",
-      }
-    }
+  <DndProvider
+    backend={[Function]}
   >
-    <Component
-      colStartIndex={1}
-      key="1-1"
-      rowEndIndex={4}
-      rowStartIndex={1}
-    >
-      <div
-        className="flow-element start-element"
-        onClick={[Function]}
-      />
-    </Component>
-    <Component
-      colStartIndex={2}
-      key="2-1"
-      rowEndIndex={4}
-      rowStartIndex={1}
-    >
-      <StepElement
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "colStartIndex": 2,
-            "columnIndex": 2,
-            "data": Object {
-              "label": "First Node",
-            },
-            "followingElement": DivergingGatewayNode { "id": "2" },
-            "id": "1",
-            "precedingElement": StartNode,
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "step",
-          }
+    <div
+      className="flow-modeler"
+      style={
+        Object {
+          "gridTemplateColumns": "repeat(8, max-content)",
         }
-      >
-        First Node
-      </StepElement>
-    </Component>
-    <Component
-      colStartIndex={3}
-      key="3-1"
-      rowEndIndex={4}
-      rowStartIndex={1}
-    >
-      <Gateway
-        gateway={
-          Object {
-            "colStartIndex": 3,
-            "columnIndex": 3,
-            "data": Object {
-              "label": "Alternatives",
-            },
-            "followingBranches": Array [
-              DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-              DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-              DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-            ],
-            "id": "2",
-            "precedingElement": StepNode { "id": "1" },
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "div-gw",
-          }
-        }
-        onSelect={[Function]}
-      />
-    </Component>
-    <Component
-      colStartIndex={4}
-      key="4-1"
-      rowEndIndex={2}
-      rowStartIndex={1}
-    >
-      <HorizontalStroke
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "branchIndex": 0,
-            "colEndIndex": undefined,
-            "colStartIndex": 4,
-            "columnIndex": 4,
-            "connectionType": 1,
-            "data": Object {
-              "label": "Stop Here",
-            },
-            "followingElement": ConvergingGatewayBranch,
-            "precedingElement": DivergingGatewayNode { "id": "2" },
-            "rowCount": 1,
-            "rowEndIndex": 2,
-            "rowStartIndex": 1,
-            "type": "div-branch",
-          }
-        }
-      />
-    </Component>
-    <Component
-      colEndIndex={7}
-      colStartIndex={5}
-      key="5-1"
-      rowEndIndex={2}
-      rowStartIndex={1}
-    >
-      <div
-        className="stroke-horizontal"
-      />
-      <div
-        className="stroke-vertical bottom-half"
-      />
-    </Component>
-    <Component
-      colStartIndex={7}
-      key="7-1"
-      rowEndIndex={4}
-      rowStartIndex={1}
-    >
-      <Gateway
-        gateway={
-          Object {
-            "colStartIndex": 7,
-            "columnIndex": 7,
-            "followingElement": EndNode,
-            "precedingBranches": Array [
-              ConvergingGatewayBranch,
-              ConvergingGatewayBranch,
-              ConvergingGatewayBranch,
-            ],
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "conv-gw",
-          }
-        }
-        onSelect={[Function]}
-      />
-    </Component>
-    <Component
-      colStartIndex={8}
-      key="8-1"
-      rowEndIndex={4}
-      rowStartIndex={1}
+      }
     >
       <Component
-        elementTypeClassName="end-element"
-        referenceElement={
-          Object {
-            "colStartIndex": 8,
-            "columnIndex": 8,
-            "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
-            "rowCount": 3,
-            "rowEndIndex": 4,
-            "rowStartIndex": 1,
-            "type": "end",
-          }
-        }
-      />
-    </Component>
-    <Component
-      colStartIndex={4}
-      key="4-2"
-      rowEndIndex={3}
-      rowStartIndex={2}
-    >
-      <HorizontalStroke
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "branchIndex": 1,
-            "colEndIndex": undefined,
-            "colStartIndex": 4,
-            "columnIndex": 4,
-            "connectionType": 2,
-            "data": Object {
-              "label": "Continue",
-            },
-            "followingElement": StepNode { "id": "3.2" },
-            "precedingElement": DivergingGatewayNode { "id": "2" },
-            "rowCount": 1,
-            "rowEndIndex": 3,
-            "rowStartIndex": 2,
-            "type": "div-branch",
-          }
-        }
-      />
-    </Component>
-    <Component
-      colStartIndex={5}
-      key="5-2"
-      rowEndIndex={3}
-      rowStartIndex={2}
-    >
-      <StepElement
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "colStartIndex": 5,
-            "columnIndex": 5,
-            "data": Object {
-              "label": "Second Node",
-            },
-            "followingElement": ConvergingGatewayBranch,
-            "id": "3.2",
-            "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-            "rowCount": 1,
-            "rowEndIndex": 3,
-            "rowStartIndex": 2,
-            "type": "step",
-          }
-        }
+        colStartIndex={1}
+        key="1-1"
+        rowEndIndex={4}
+        rowStartIndex={1}
       >
-        Second Node
-      </StepElement>
-    </Component>
-    <Component
-      colEndIndex={7}
-      colStartIndex={6}
-      key="6-2"
-      rowEndIndex={3}
-      rowStartIndex={2}
-    >
-      <div
-        className="stroke-horizontal"
-      />
-      <div
-        className="stroke-vertical full-height"
-      />
-    </Component>
-    <Component
-      colStartIndex={4}
-      key="4-3"
-      rowEndIndex={4}
-      rowStartIndex={3}
-    >
-      <HorizontalStroke
-        onSelect={[Function]}
-        referenceElement={
-          Object {
-            "branchIndex": 2,
-            "colEndIndex": undefined,
-            "colStartIndex": 4,
-            "columnIndex": 4,
-            "connectionType": 3,
-            "data": Object {
-              "label": "Unless it is already done",
-            },
-            "followingElement": ConvergingGatewayBranch,
-            "precedingElement": DivergingGatewayNode { "id": "2" },
-            "rowCount": 1,
-            "rowEndIndex": 4,
-            "rowStartIndex": 3,
-            "type": "div-branch",
+        <div
+          className="flow-element start-element"
+          onClick={[Function]}
+        />
+      </Component>
+      <Component
+        colStartIndex={2}
+        key="2-1"
+        rowEndIndex={4}
+        rowStartIndex={1}
+      >
+        <StepElement
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "colStartIndex": 2,
+              "columnIndex": 2,
+              "data": Object {
+                "label": "First Node",
+              },
+              "followingElement": DivergingGatewayNode { "id": "2" },
+              "id": "1",
+              "precedingElement": StartNode,
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "step",
+            }
           }
-        }
-      />
-    </Component>
-    <Component
-      colEndIndex={7}
-      colStartIndex={5}
-      key="5-3"
-      rowEndIndex={4}
-      rowStartIndex={3}
-    >
-      <div
-        className="stroke-horizontal"
-      />
-      <div
-        className="stroke-vertical top-half"
-      />
-    </Component>
-  </div>
-</DndProvider>
+        >
+          First Node
+        </StepElement>
+      </Component>
+      <Component
+        colStartIndex={3}
+        key="3-1"
+        rowEndIndex={4}
+        rowStartIndex={1}
+      >
+        <Gateway
+          gateway={
+            Object {
+              "colStartIndex": 3,
+              "columnIndex": 3,
+              "data": Object {
+                "label": "Alternatives",
+              },
+              "followingBranches": Array [
+                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+                DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+              ],
+              "id": "2",
+              "precedingElement": StepNode { "id": "1" },
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "div-gw",
+            }
+          }
+          onSelect={[Function]}
+        />
+      </Component>
+      <Component
+        colStartIndex={4}
+        key="4-1"
+        rowEndIndex={2}
+        rowStartIndex={1}
+      >
+        <HorizontalStroke
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "branchIndex": 0,
+              "colEndIndex": undefined,
+              "colStartIndex": 4,
+              "columnIndex": 4,
+              "connectionType": 1,
+              "data": Object {
+                "label": "Stop Here",
+              },
+              "followingElement": ConvergingGatewayBranch,
+              "precedingElement": DivergingGatewayNode { "id": "2" },
+              "rowCount": 1,
+              "rowEndIndex": 2,
+              "rowStartIndex": 1,
+              "type": "div-branch",
+            }
+          }
+        />
+      </Component>
+      <Component
+        colEndIndex={7}
+        colStartIndex={5}
+        key="5-1"
+        rowEndIndex={2}
+        rowStartIndex={1}
+      >
+        <div
+          className="stroke-horizontal"
+        />
+        <div
+          className="stroke-vertical bottom-half"
+        />
+      </Component>
+      <Component
+        colStartIndex={7}
+        key="7-1"
+        rowEndIndex={4}
+        rowStartIndex={1}
+      >
+        <Gateway
+          gateway={
+            Object {
+              "colStartIndex": 7,
+              "columnIndex": 7,
+              "followingElement": EndNode,
+              "precedingBranches": Array [
+                ConvergingGatewayBranch,
+                ConvergingGatewayBranch,
+                ConvergingGatewayBranch,
+              ],
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "conv-gw",
+            }
+          }
+          onSelect={[Function]}
+        />
+      </Component>
+      <Component
+        colStartIndex={8}
+        key="8-1"
+        rowEndIndex={4}
+        rowStartIndex={1}
+      >
+        <Component
+          elementTypeClassName="end-element"
+          referenceElement={
+            Object {
+              "colStartIndex": 8,
+              "columnIndex": 8,
+              "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
+              "rowCount": 3,
+              "rowEndIndex": 4,
+              "rowStartIndex": 1,
+              "type": "end",
+            }
+          }
+        />
+      </Component>
+      <Component
+        colStartIndex={4}
+        key="4-2"
+        rowEndIndex={3}
+        rowStartIndex={2}
+      >
+        <HorizontalStroke
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "branchIndex": 1,
+              "colEndIndex": undefined,
+              "colStartIndex": 4,
+              "columnIndex": 4,
+              "connectionType": 2,
+              "data": Object {
+                "label": "Continue",
+              },
+              "followingElement": StepNode { "id": "3.2" },
+              "precedingElement": DivergingGatewayNode { "id": "2" },
+              "rowCount": 1,
+              "rowEndIndex": 3,
+              "rowStartIndex": 2,
+              "type": "div-branch",
+            }
+          }
+        />
+      </Component>
+      <Component
+        colStartIndex={5}
+        key="5-2"
+        rowEndIndex={3}
+        rowStartIndex={2}
+      >
+        <StepElement
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "colStartIndex": 5,
+              "columnIndex": 5,
+              "data": Object {
+                "label": "Second Node",
+              },
+              "followingElement": ConvergingGatewayBranch,
+              "id": "3.2",
+              "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+              "rowCount": 1,
+              "rowEndIndex": 3,
+              "rowStartIndex": 2,
+              "type": "step",
+            }
+          }
+        >
+          Second Node
+        </StepElement>
+      </Component>
+      <Component
+        colEndIndex={7}
+        colStartIndex={6}
+        key="6-2"
+        rowEndIndex={3}
+        rowStartIndex={2}
+      >
+        <div
+          className="stroke-horizontal"
+        />
+        <div
+          className="stroke-vertical full-height"
+        />
+      </Component>
+      <Component
+        colStartIndex={4}
+        key="4-3"
+        rowEndIndex={4}
+        rowStartIndex={3}
+      >
+        <HorizontalStroke
+          onSelect={[Function]}
+          referenceElement={
+            Object {
+              "branchIndex": 2,
+              "colEndIndex": undefined,
+              "colStartIndex": 4,
+              "columnIndex": 4,
+              "connectionType": 3,
+              "data": Object {
+                "label": "Unless it is already done",
+              },
+              "followingElement": ConvergingGatewayBranch,
+              "precedingElement": DivergingGatewayNode { "id": "2" },
+              "rowCount": 1,
+              "rowEndIndex": 4,
+              "rowStartIndex": 3,
+              "type": "div-branch",
+            }
+          }
+        />
+      </Component>
+      <Component
+        colEndIndex={7}
+        colStartIndex={5}
+        key="5-3"
+        rowEndIndex={4}
+        rowStartIndex={3}
+      >
+        <div
+          className="stroke-horizontal"
+        />
+        <div
+          className="stroke-vertical top-half"
+        />
+      </Component>
+    </div>
+  </DndProvider>
+</OutsideClickHandler>
 `;

--- a/test/component/__snapshots__/FlowModeler.test.tsx.snap
+++ b/test/component/__snapshots__/FlowModeler.test.tsx.snap
@@ -1,591 +1,569 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders correctly with all render props 1`] = `
-<OutsideClickHandler
-  disabled={false}
-  display="block"
-  onOutsideClick={[Function]}
-  useCapture={true}
+<div
+  className="flow-modeler"
+  style={
+    Object {
+      "gridTemplateColumns": "repeat(8, max-content)",
+    }
+  }
 >
-  <DndProvider
-    backend={[Function]}
+  <Component
+    colStartIndex={1}
+    key="1-1"
+    rowStartIndex={3}
   >
     <div
-      className="flow-modeler"
-      style={
+      className="flow-element start-element"
+      onClick={[Function]}
+    />
+  </Component>
+  <Component
+    colStartIndex={2}
+    key="2-1"
+    rowStartIndex={3}
+  >
+    <StepElement
+      onSelect={[Function]}
+      referenceElement={
         Object {
-          "gridTemplateColumns": "repeat(8, max-content)",
+          "colStartIndex": 2,
+          "columnIndex": 2,
+          "data": Object {
+            "label": "First Node",
+          },
+          "followingElement": DivergingGatewayNode { "id": "2" },
+          "id": "1",
+          "precedingElement": StartNode,
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "step",
         }
       }
     >
-      <Component
-        colStartIndex={1}
-        key="1-1"
-        rowStartIndex={3}
-      >
-        <div
-          className="flow-element start-element"
-          onClick={[Function]}
-        />
-      </Component>
-      <Component
-        colStartIndex={2}
-        key="2-1"
-        rowStartIndex={3}
-      >
-        <StepElement
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "colStartIndex": 2,
-              "columnIndex": 2,
-              "data": Object {
-                "label": "First Node",
-              },
-              "followingElement": DivergingGatewayNode { "id": "2" },
-              "id": "1",
-              "precedingElement": StartNode,
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "step",
-            }
-          }
-        >
-          First Node
-        </StepElement>
-      </Component>
-      <Component
-        colStartIndex={3}
-        key="3-1"
-        rowStartIndex={3}
-      >
-        <Gateway
-          gateway={
-            Object {
-              "colStartIndex": 3,
-              "columnIndex": 3,
-              "data": Object {
-                "label": "Alternatives",
-              },
-              "followingBranches": Array [
-                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-                DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-              ],
-              "id": "2",
-              "precedingElement": StepNode { "id": "1" },
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "div-gw",
-            }
-          }
-          onSelect={[Function]}
-        >
-          <label>
-            Alternatives
-          </label>
-        </Gateway>
-      </Component>
-      <Component
-        colStartIndex={4}
-        key="4-1"
-        rowStartIndex={1}
-      >
-        <HorizontalStroke
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "branchIndex": 0,
-              "colEndIndex": undefined,
-              "colStartIndex": 4,
-              "columnIndex": 4,
-              "connectionType": 1,
-              "data": Object {
-                "label": "Stop Here",
-              },
-              "followingElement": ConvergingGatewayBranch,
-              "precedingElement": DivergingGatewayNode { "id": "2" },
-              "rowCount": 1,
-              "rowEndIndex": 2,
-              "rowStartIndex": 1,
-              "type": "div-branch",
-            }
-          }
-        >
-          <span>
-            Stop Here
-          </span>
-        </HorizontalStroke>
-      </Component>
-      <Component
-        colEndIndex={7}
-        colStartIndex={5}
-        key="5-1"
-        rowStartIndex={1}
-      >
-        <div
-          className="stroke-horizontal"
-        />
-        <div
-          className="stroke-vertical bottom-half"
-        />
-      </Component>
-      <Component
-        colStartIndex={7}
-        key="7-1"
-        rowStartIndex={3}
-      >
-        <Gateway
-          gateway={
-            Object {
-              "colStartIndex": 7,
-              "columnIndex": 7,
-              "followingElement": EndNode,
-              "precedingBranches": Array [
-                ConvergingGatewayBranch,
-                ConvergingGatewayBranch,
-                ConvergingGatewayBranch,
-              ],
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "conv-gw",
-            }
-          }
-          onSelect={[Function]}
-        />
-      </Component>
-      <Component
-        colStartIndex={8}
-        key="8-1"
-        rowStartIndex={3}
-      >
-        <Component
-          elementTypeClassName="end-element"
-          referenceElement={
-            Object {
-              "colStartIndex": 8,
-              "columnIndex": 8,
-              "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "end",
-            }
-          }
-        />
-      </Component>
-      <Component
-        colStartIndex={4}
-        key="4-2"
-        rowStartIndex={2}
-      >
-        <HorizontalStroke
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "branchIndex": 1,
-              "colEndIndex": undefined,
-              "colStartIndex": 4,
-              "columnIndex": 4,
-              "connectionType": 2,
-              "data": Object {
-                "label": "Continue",
-              },
-              "followingElement": StepNode { "id": "3.2" },
-              "precedingElement": DivergingGatewayNode { "id": "2" },
-              "rowCount": 1,
-              "rowEndIndex": 3,
-              "rowStartIndex": 2,
-              "type": "div-branch",
-            }
-          }
-        >
-          <span>
-            Continue
-          </span>
-        </HorizontalStroke>
-      </Component>
-      <Component
-        colStartIndex={5}
-        key="5-2"
-        rowStartIndex={2}
-      >
-        <StepElement
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "colStartIndex": 5,
-              "columnIndex": 5,
-              "data": Object {
-                "label": "Second Node",
-              },
-              "followingElement": ConvergingGatewayBranch,
-              "id": "3.2",
-              "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-              "rowCount": 1,
-              "rowEndIndex": 3,
-              "rowStartIndex": 2,
-              "type": "step",
-            }
-          }
-        >
-          Second Node
-        </StepElement>
-      </Component>
-      <Component
-        colEndIndex={7}
-        colStartIndex={6}
-        key="6-2"
-        rowStartIndex={2}
-      >
-        <div
-          className="stroke-horizontal"
-        />
-        <div
-          className="stroke-vertical full-height"
-        />
-      </Component>
-      <Component
-        colStartIndex={4}
-        key="4-3"
-        rowStartIndex={3}
-      >
-        <HorizontalStroke
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "branchIndex": 2,
-              "colEndIndex": undefined,
-              "colStartIndex": 4,
-              "columnIndex": 4,
-              "connectionType": 3,
-              "data": Object {
-                "label": "Unless it is already done",
-              },
-              "followingElement": ConvergingGatewayBranch,
-              "precedingElement": DivergingGatewayNode { "id": "2" },
-              "rowCount": 1,
-              "rowEndIndex": 4,
-              "rowStartIndex": 3,
-              "type": "div-branch",
-            }
-          }
-        >
-          <span>
-            Unless it is already done
-          </span>
-        </HorizontalStroke>
-      </Component>
-      <Component
-        colEndIndex={7}
-        colStartIndex={5}
-        key="5-3"
-        rowStartIndex={3}
-      >
-        <div
-          className="stroke-horizontal"
-        />
-        <div
-          className="stroke-vertical top-half"
-        />
-      </Component>
-    </div>
-  </DndProvider>
-</OutsideClickHandler>
+      First Node
+    </StepElement>
+  </Component>
+  <Component
+    colStartIndex={3}
+    key="3-1"
+    rowStartIndex={3}
+  >
+    <Gateway
+      gateway={
+        Object {
+          "colStartIndex": 3,
+          "columnIndex": 3,
+          "data": Object {
+            "label": "Alternatives",
+          },
+          "followingBranches": Array [
+            DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+            DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+            DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+          ],
+          "id": "2",
+          "precedingElement": StepNode { "id": "1" },
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "div-gw",
+        }
+      }
+      onSelect={[Function]}
+    >
+      <label>
+        Alternatives
+      </label>
+    </Gateway>
+  </Component>
+  <Component
+    colStartIndex={4}
+    key="4-1"
+    rowStartIndex={1}
+  >
+    <HorizontalStroke
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "branchIndex": 0,
+          "colEndIndex": undefined,
+          "colStartIndex": 4,
+          "columnIndex": 4,
+          "connectionType": 1,
+          "data": Object {
+            "label": "Stop Here",
+          },
+          "followingElement": ConvergingGatewayBranch,
+          "precedingElement": DivergingGatewayNode { "id": "2" },
+          "rowCount": 1,
+          "rowEndIndex": 2,
+          "rowStartIndex": 1,
+          "type": "div-branch",
+        }
+      }
+    >
+      <span>
+        Stop Here
+      </span>
+    </HorizontalStroke>
+  </Component>
+  <Component
+    colEndIndex={7}
+    colStartIndex={5}
+    key="5-1"
+    rowStartIndex={1}
+  >
+    <div
+      className="stroke-horizontal"
+    />
+    <div
+      className="stroke-vertical bottom-half"
+    />
+  </Component>
+  <Component
+    colStartIndex={7}
+    key="7-1"
+    rowStartIndex={3}
+  >
+    <Gateway
+      gateway={
+        Object {
+          "colStartIndex": 7,
+          "columnIndex": 7,
+          "followingElement": EndNode,
+          "precedingBranches": Array [
+            ConvergingGatewayBranch,
+            ConvergingGatewayBranch,
+            ConvergingGatewayBranch,
+          ],
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "conv-gw",
+        }
+      }
+      onSelect={[Function]}
+    />
+  </Component>
+  <Component
+    colStartIndex={8}
+    key="8-1"
+    rowStartIndex={3}
+  >
+    <Component
+      elementTypeClassName="end-element"
+      referenceElement={
+        Object {
+          "colStartIndex": 8,
+          "columnIndex": 8,
+          "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "end",
+        }
+      }
+    />
+  </Component>
+  <Component
+    colStartIndex={4}
+    key="4-2"
+    rowStartIndex={2}
+  >
+    <HorizontalStroke
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "branchIndex": 1,
+          "colEndIndex": undefined,
+          "colStartIndex": 4,
+          "columnIndex": 4,
+          "connectionType": 2,
+          "data": Object {
+            "label": "Continue",
+          },
+          "followingElement": StepNode { "id": "3.2" },
+          "precedingElement": DivergingGatewayNode { "id": "2" },
+          "rowCount": 1,
+          "rowEndIndex": 3,
+          "rowStartIndex": 2,
+          "type": "div-branch",
+        }
+      }
+    >
+      <span>
+        Continue
+      </span>
+    </HorizontalStroke>
+  </Component>
+  <Component
+    colStartIndex={5}
+    key="5-2"
+    rowStartIndex={2}
+  >
+    <StepElement
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "colStartIndex": 5,
+          "columnIndex": 5,
+          "data": Object {
+            "label": "Second Node",
+          },
+          "followingElement": ConvergingGatewayBranch,
+          "id": "3.2",
+          "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+          "rowCount": 1,
+          "rowEndIndex": 3,
+          "rowStartIndex": 2,
+          "type": "step",
+        }
+      }
+    >
+      Second Node
+    </StepElement>
+  </Component>
+  <Component
+    colEndIndex={7}
+    colStartIndex={6}
+    key="6-2"
+    rowStartIndex={2}
+  >
+    <div
+      className="stroke-horizontal"
+    />
+    <div
+      className="stroke-vertical full-height"
+    />
+  </Component>
+  <Component
+    colStartIndex={4}
+    key="4-3"
+    rowStartIndex={3}
+  >
+    <HorizontalStroke
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "branchIndex": 2,
+          "colEndIndex": undefined,
+          "colStartIndex": 4,
+          "columnIndex": 4,
+          "connectionType": 3,
+          "data": Object {
+            "label": "Unless it is already done",
+          },
+          "followingElement": ConvergingGatewayBranch,
+          "precedingElement": DivergingGatewayNode { "id": "2" },
+          "rowCount": 1,
+          "rowEndIndex": 4,
+          "rowStartIndex": 3,
+          "type": "div-branch",
+        }
+      }
+    >
+      <span>
+        Unless it is already done
+      </span>
+    </HorizontalStroke>
+  </Component>
+  <Component
+    colEndIndex={7}
+    colStartIndex={5}
+    key="5-3"
+    rowStartIndex={3}
+  >
+    <div
+      className="stroke-horizontal"
+    />
+    <div
+      className="stroke-vertical top-half"
+    />
+  </Component>
+</div>
 `;
 
 exports[`renders correctly with minimal/default props 1`] = `
-<OutsideClickHandler
-  disabled={false}
-  display="block"
-  onOutsideClick={[Function]}
-  useCapture={true}
+<div
+  className="flow-modeler"
+  style={
+    Object {
+      "gridTemplateColumns": "repeat(8, max-content)",
+    }
+  }
 >
-  <DndProvider
-    backend={[Function]}
+  <Component
+    colStartIndex={1}
+    key="1-1"
+    rowEndIndex={4}
+    rowStartIndex={1}
   >
     <div
-      className="flow-modeler"
-      style={
+      className="flow-element start-element"
+      onClick={[Function]}
+    />
+  </Component>
+  <Component
+    colStartIndex={2}
+    key="2-1"
+    rowEndIndex={4}
+    rowStartIndex={1}
+  >
+    <StepElement
+      onSelect={[Function]}
+      referenceElement={
         Object {
-          "gridTemplateColumns": "repeat(8, max-content)",
+          "colStartIndex": 2,
+          "columnIndex": 2,
+          "data": Object {
+            "label": "First Node",
+          },
+          "followingElement": DivergingGatewayNode { "id": "2" },
+          "id": "1",
+          "precedingElement": StartNode,
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "step",
         }
       }
     >
-      <Component
-        colStartIndex={1}
-        key="1-1"
-        rowEndIndex={4}
-        rowStartIndex={1}
-      >
-        <div
-          className="flow-element start-element"
-          onClick={[Function]}
-        />
-      </Component>
-      <Component
-        colStartIndex={2}
-        key="2-1"
-        rowEndIndex={4}
-        rowStartIndex={1}
-      >
-        <StepElement
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "colStartIndex": 2,
-              "columnIndex": 2,
-              "data": Object {
-                "label": "First Node",
-              },
-              "followingElement": DivergingGatewayNode { "id": "2" },
-              "id": "1",
-              "precedingElement": StartNode,
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "step",
-            }
-          }
-        >
-          First Node
-        </StepElement>
-      </Component>
-      <Component
-        colStartIndex={3}
-        key="3-1"
-        rowEndIndex={4}
-        rowStartIndex={1}
-      >
-        <Gateway
-          gateway={
-            Object {
-              "colStartIndex": 3,
-              "columnIndex": 3,
-              "data": Object {
-                "label": "Alternatives",
-              },
-              "followingBranches": Array [
-                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-                DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-                DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
-              ],
-              "id": "2",
-              "precedingElement": StepNode { "id": "1" },
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "div-gw",
-            }
-          }
-          onSelect={[Function]}
-        />
-      </Component>
-      <Component
-        colStartIndex={4}
-        key="4-1"
-        rowEndIndex={2}
-        rowStartIndex={1}
-      >
-        <HorizontalStroke
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "branchIndex": 0,
-              "colEndIndex": undefined,
-              "colStartIndex": 4,
-              "columnIndex": 4,
-              "connectionType": 1,
-              "data": Object {
-                "label": "Stop Here",
-              },
-              "followingElement": ConvergingGatewayBranch,
-              "precedingElement": DivergingGatewayNode { "id": "2" },
-              "rowCount": 1,
-              "rowEndIndex": 2,
-              "rowStartIndex": 1,
-              "type": "div-branch",
-            }
-          }
-        />
-      </Component>
-      <Component
-        colEndIndex={7}
-        colStartIndex={5}
-        key="5-1"
-        rowEndIndex={2}
-        rowStartIndex={1}
-      >
-        <div
-          className="stroke-horizontal"
-        />
-        <div
-          className="stroke-vertical bottom-half"
-        />
-      </Component>
-      <Component
-        colStartIndex={7}
-        key="7-1"
-        rowEndIndex={4}
-        rowStartIndex={1}
-      >
-        <Gateway
-          gateway={
-            Object {
-              "colStartIndex": 7,
-              "columnIndex": 7,
-              "followingElement": EndNode,
-              "precedingBranches": Array [
-                ConvergingGatewayBranch,
-                ConvergingGatewayBranch,
-                ConvergingGatewayBranch,
-              ],
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "conv-gw",
-            }
-          }
-          onSelect={[Function]}
-        />
-      </Component>
-      <Component
-        colStartIndex={8}
-        key="8-1"
-        rowEndIndex={4}
-        rowStartIndex={1}
-      >
-        <Component
-          elementTypeClassName="end-element"
-          referenceElement={
-            Object {
-              "colStartIndex": 8,
-              "columnIndex": 8,
-              "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
-              "rowCount": 3,
-              "rowEndIndex": 4,
-              "rowStartIndex": 1,
-              "type": "end",
-            }
-          }
-        />
-      </Component>
-      <Component
-        colStartIndex={4}
-        key="4-2"
-        rowEndIndex={3}
-        rowStartIndex={2}
-      >
-        <HorizontalStroke
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "branchIndex": 1,
-              "colEndIndex": undefined,
-              "colStartIndex": 4,
-              "columnIndex": 4,
-              "connectionType": 2,
-              "data": Object {
-                "label": "Continue",
-              },
-              "followingElement": StepNode { "id": "3.2" },
-              "precedingElement": DivergingGatewayNode { "id": "2" },
-              "rowCount": 1,
-              "rowEndIndex": 3,
-              "rowStartIndex": 2,
-              "type": "div-branch",
-            }
-          }
-        />
-      </Component>
-      <Component
-        colStartIndex={5}
-        key="5-2"
-        rowEndIndex={3}
-        rowStartIndex={2}
-      >
-        <StepElement
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "colStartIndex": 5,
-              "columnIndex": 5,
-              "data": Object {
-                "label": "Second Node",
-              },
-              "followingElement": ConvergingGatewayBranch,
-              "id": "3.2",
-              "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
-              "rowCount": 1,
-              "rowEndIndex": 3,
-              "rowStartIndex": 2,
-              "type": "step",
-            }
-          }
-        >
-          Second Node
-        </StepElement>
-      </Component>
-      <Component
-        colEndIndex={7}
-        colStartIndex={6}
-        key="6-2"
-        rowEndIndex={3}
-        rowStartIndex={2}
-      >
-        <div
-          className="stroke-horizontal"
-        />
-        <div
-          className="stroke-vertical full-height"
-        />
-      </Component>
-      <Component
-        colStartIndex={4}
-        key="4-3"
-        rowEndIndex={4}
-        rowStartIndex={3}
-      >
-        <HorizontalStroke
-          onSelect={[Function]}
-          referenceElement={
-            Object {
-              "branchIndex": 2,
-              "colEndIndex": undefined,
-              "colStartIndex": 4,
-              "columnIndex": 4,
-              "connectionType": 3,
-              "data": Object {
-                "label": "Unless it is already done",
-              },
-              "followingElement": ConvergingGatewayBranch,
-              "precedingElement": DivergingGatewayNode { "id": "2" },
-              "rowCount": 1,
-              "rowEndIndex": 4,
-              "rowStartIndex": 3,
-              "type": "div-branch",
-            }
-          }
-        />
-      </Component>
-      <Component
-        colEndIndex={7}
-        colStartIndex={5}
-        key="5-3"
-        rowEndIndex={4}
-        rowStartIndex={3}
-      >
-        <div
-          className="stroke-horizontal"
-        />
-        <div
-          className="stroke-vertical top-half"
-        />
-      </Component>
-    </div>
-  </DndProvider>
-</OutsideClickHandler>
+      First Node
+    </StepElement>
+  </Component>
+  <Component
+    colStartIndex={3}
+    key="3-1"
+    rowEndIndex={4}
+    rowStartIndex={1}
+  >
+    <Gateway
+      gateway={
+        Object {
+          "colStartIndex": 3,
+          "columnIndex": 3,
+          "data": Object {
+            "label": "Alternatives",
+          },
+          "followingBranches": Array [
+            DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+            DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+            DivergingGatewayBranch { "followingElement": ConvergingGatewayBranch },
+          ],
+          "id": "2",
+          "precedingElement": StepNode { "id": "1" },
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "div-gw",
+        }
+      }
+      onSelect={[Function]}
+    />
+  </Component>
+  <Component
+    colStartIndex={4}
+    key="4-1"
+    rowEndIndex={2}
+    rowStartIndex={1}
+  >
+    <HorizontalStroke
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "branchIndex": 0,
+          "colEndIndex": undefined,
+          "colStartIndex": 4,
+          "columnIndex": 4,
+          "connectionType": 1,
+          "data": Object {
+            "label": "Stop Here",
+          },
+          "followingElement": ConvergingGatewayBranch,
+          "precedingElement": DivergingGatewayNode { "id": "2" },
+          "rowCount": 1,
+          "rowEndIndex": 2,
+          "rowStartIndex": 1,
+          "type": "div-branch",
+        }
+      }
+    />
+  </Component>
+  <Component
+    colEndIndex={7}
+    colStartIndex={5}
+    key="5-1"
+    rowEndIndex={2}
+    rowStartIndex={1}
+  >
+    <div
+      className="stroke-horizontal"
+    />
+    <div
+      className="stroke-vertical bottom-half"
+    />
+  </Component>
+  <Component
+    colStartIndex={7}
+    key="7-1"
+    rowEndIndex={4}
+    rowStartIndex={1}
+  >
+    <Gateway
+      gateway={
+        Object {
+          "colStartIndex": 7,
+          "columnIndex": 7,
+          "followingElement": EndNode,
+          "precedingBranches": Array [
+            ConvergingGatewayBranch,
+            ConvergingGatewayBranch,
+            ConvergingGatewayBranch,
+          ],
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "conv-gw",
+        }
+      }
+      onSelect={[Function]}
+    />
+  </Component>
+  <Component
+    colStartIndex={8}
+    key="8-1"
+    rowEndIndex={4}
+    rowStartIndex={1}
+  >
+    <Component
+      elementTypeClassName="end-element"
+      referenceElement={
+        Object {
+          "colStartIndex": 8,
+          "columnIndex": 8,
+          "precedingElement": ConvergingGatewayNode { "followingElement": EndNode },
+          "rowCount": 3,
+          "rowEndIndex": 4,
+          "rowStartIndex": 1,
+          "type": "end",
+        }
+      }
+    />
+  </Component>
+  <Component
+    colStartIndex={4}
+    key="4-2"
+    rowEndIndex={3}
+    rowStartIndex={2}
+  >
+    <HorizontalStroke
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "branchIndex": 1,
+          "colEndIndex": undefined,
+          "colStartIndex": 4,
+          "columnIndex": 4,
+          "connectionType": 2,
+          "data": Object {
+            "label": "Continue",
+          },
+          "followingElement": StepNode { "id": "3.2" },
+          "precedingElement": DivergingGatewayNode { "id": "2" },
+          "rowCount": 1,
+          "rowEndIndex": 3,
+          "rowStartIndex": 2,
+          "type": "div-branch",
+        }
+      }
+    />
+  </Component>
+  <Component
+    colStartIndex={5}
+    key="5-2"
+    rowEndIndex={3}
+    rowStartIndex={2}
+  >
+    <StepElement
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "colStartIndex": 5,
+          "columnIndex": 5,
+          "data": Object {
+            "label": "Second Node",
+          },
+          "followingElement": ConvergingGatewayBranch,
+          "id": "3.2",
+          "precedingElement": DivergingGatewayBranch { "followingElement": StepNode { "id": "3.2" } },
+          "rowCount": 1,
+          "rowEndIndex": 3,
+          "rowStartIndex": 2,
+          "type": "step",
+        }
+      }
+    >
+      Second Node
+    </StepElement>
+  </Component>
+  <Component
+    colEndIndex={7}
+    colStartIndex={6}
+    key="6-2"
+    rowEndIndex={3}
+    rowStartIndex={2}
+  >
+    <div
+      className="stroke-horizontal"
+    />
+    <div
+      className="stroke-vertical full-height"
+    />
+  </Component>
+  <Component
+    colStartIndex={4}
+    key="4-3"
+    rowEndIndex={4}
+    rowStartIndex={3}
+  >
+    <HorizontalStroke
+      onSelect={[Function]}
+      referenceElement={
+        Object {
+          "branchIndex": 2,
+          "colEndIndex": undefined,
+          "colStartIndex": 4,
+          "columnIndex": 4,
+          "connectionType": 3,
+          "data": Object {
+            "label": "Unless it is already done",
+          },
+          "followingElement": ConvergingGatewayBranch,
+          "precedingElement": DivergingGatewayNode { "id": "2" },
+          "rowCount": 1,
+          "rowEndIndex": 4,
+          "rowStartIndex": 3,
+          "type": "div-branch",
+        }
+      }
+    />
+  </Component>
+  <Component
+    colEndIndex={7}
+    colStartIndex={5}
+    key="5-3"
+    rowEndIndex={4}
+    rowStartIndex={3}
+  >
+    <div
+      className="stroke-horizontal"
+    />
+    <div
+      className="stroke-vertical top-half"
+    />
+  </Component>
+</div>
 `;

--- a/test/component/__snapshots__/HorizontalStroke.test.tsx.snap
+++ b/test/component/__snapshots__/HorizontalStroke.test.tsx.snap
@@ -21,7 +21,12 @@ exports[`renders correctly with minimal/default props 1`] = `
     </div>
     <div
       className="bottom-spacing"
-    />
+    >
+      <div
+        className="clickable-spacing"
+        onClick={[Function]}
+      />
+    </div>
   </div>
 </HorizontalStroke>
 `;


### PR DESCRIPTION
- introducing `react-outside-click-handler` dependency, in order to clear selection when registering a click outside the modeler component
- extend selectable area for diverging branches
- add option to omit `DndProvider` to avoid multiple `DndProvider` instances being present if it is already being used by the surrounding application